### PR TITLE
Add $KAFKA_HOME/bin to PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV SCALA_VERSION 2.11
 ENV KAFKA_VERSION 0.10.2.1
 ENV KAFKA_HOME /opt/kafka_"$SCALA_VERSION"-"$KAFKA_VERSION"
+ENV PATH "$PATH:$KAFKA_HOME/bin"
 
 # Install Kafka, Zookeeper and other needed things
 RUN apt-get update && \


### PR DESCRIPTION
To make running Kafka commands easier and avoid having to hardcode the version into scripts, this adds `$KAFKA_HOME/bin` to `PATH`