### PR TITLE
Added support for configurable kafka hostname via env var

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,12 @@ RUN apt-get update && \
     rm /tmp/kafka_"$SCALA_VERSION"-"$KAFKA_VERSION".tgz
 
 ADD scripts/start-kafka.sh /usr/bin/start-kafka.sh
+ADD scripts/config.py $KAFKA_HOME/bin
 
 # Supervisor config
 ADD supervisor/kafka.conf supervisor/kafka2.conf supervisor/zookeeper.conf /etc/supervisor/conf.d/
 
-ADD config/server.properties config/server2.properties $KAFKA_HOME/config/
+ADD config/server.properties.template config/server2.properties.template $KAFKA_HOME/config/
 
 # 2181 is zookeeper, 9092 is kafka 9192 is kafka2
 EXPOSE 2181 9092 9192

--- a/config/server.properties.template
+++ b/config/server.properties.template
@@ -19,7 +19,8 @@ inter.broker.listener.name=REPLICATION
 # Hostname and port the broker will advertise to producers and consumers. If not set,
 # it uses the value for "listeners" if configured.  Otherwise, it will use the value
 # returned from java.net.InetAddress.getCanonicalHostName().
-advertised.listeners=CLIENT://0.0.0.0:9092,REPLICATION://0.0.0.0:9093
+advertised.host.name=${kafka_hostname}
+advertised.listeners=CLIENT://${kafka_hostname}:9092,REPLICATION://0.0.0.0:9093
 
 ############################# Log Basics #############################
 

--- a/config/server2.properties.template
+++ b/config/server2.properties.template
@@ -20,7 +20,8 @@ inter.broker.listener.name=REPLICATION
 # Hostname and port the broker will advertise to producers and consumers. If not set,
 # it uses the value for "listeners" if configured.  Otherwise, it will use the value
 # returned from java.net.InetAddress.getCanonicalHostName().
-advertised.listeners=CLIENT://0.0.0.0:9192,REPLICATION://0.0.0.0:9193
+advertised.host.name=${kafka_hostname}
+advertised.listeners=CLIENT://${kafka_hostname}:9192,REPLICATION://0.0.0.0:9193
 
 ############################# Log Basics #############################
 
@@ -85,4 +86,3 @@ zookeeper.connect=localhost:2181/two
 
 # Timeout in ms for connecting to zookeeper
 zookeeper.connection.timeout.ms=6000
-

--- a/scripts/config.py
+++ b/scripts/config.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+
+import sys
+
+from string import Template
+
+def main(argv):
+    if len(argv) < 2:
+        print 'config.py <config> <hostname>'
+        sys.exit()
+
+    config = argv[0]
+    template = open( "{0}.template".format(config) )
+    s = Template( template.read() )
+
+    output = open(config, "w")
+    output.write(s.safe_substitute(kafka_hostname = argv[1]))
+    output.close()
+
+if __name__ == "__main__":
+   main(sys.argv[1:])

--- a/scripts/start-kafka.sh
+++ b/scripts/start-kafka.sh
@@ -1,4 +1,8 @@
-#!/bin/sh
+#!/bin/bash
+
+props_file=$KAFKA_HOME/config/$1
+
+$KAFKA_HOME/bin/config.py $props_file ${KAFKA_HOSTNAME:-"0.0.0.0"}
 
 # Run Kafka
-$KAFKA_HOME/bin/kafka-server-start.sh $KAFKA_HOME/config/$1
+$KAFKA_HOME/bin/kafka-server-start.sh $props_file


### PR DESCRIPTION
This allows the image to be used with `docker-compose` where the `KAFKA_HOSTNAME` may need to be something like `kafka` instead of `0.0.0.0`.